### PR TITLE
Fix layout for extra treatments

### DIFF
--- a/index.html
+++ b/index.html
@@ -201,7 +201,6 @@
           <a class="book-btn" href="https://www.bokadirekt.se/places/optima-massage-61950#book" target="_blank">Boka</a>
         </div>
         <div class="treatment extra-treatment">
-        <div class="treatment extra-treatment">
           <h3>Skräddarsydd LYX – Kundens Val – 140 min</h3>
           <p>Exklusiv skräddarsydd session baserad på dina önskemål.</p>
           <p class="price">Pris: 2 400 kr</p>


### PR DESCRIPTION
## Summary
- fix markup so `Skräddarsydd LYX – Kundens Val – 140 min` and `Expertval – Massörens Intuition – 140 min` are in separate boxes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6845d3316cf8833286d7b7e6145a7024