### PR TITLE
Center show-more button and adjust mobile logo size

### DIFF
--- a/style.css
+++ b/style.css
@@ -226,6 +226,9 @@ footer {
   border-radius: 4px;
   cursor: pointer;
   transition: background 0.3s;
+  grid-column: 1 / -1;
+  justify-self: center;
+  width: fit-content;
 }
 
 #show-more:hover {
@@ -271,6 +274,9 @@ footer {
   }
   .menu-toggle {
     display: block;
+  }
+  .logo img {
+    height: 40px;
   }
   .footer-content {
     flex-direction: column;


### PR DESCRIPTION
## Summary
- keep show-more button centered across columns in desktop view
- scale down logo on small screens for a better mobile header

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6845d72b71fc833291cdc282281325b1