### PR TITLE
Style book buttons with accent color

### DIFF
--- a/style.css
+++ b/style.css
@@ -138,6 +138,21 @@ body {
   font-weight: 700;
 }
 
+/* Booking button styling */
+.book-btn {
+  display: inline-block;
+  background: var(--accent-color);
+  color: var(--light-color);
+  padding: 0.6rem 1.2rem;
+  text-decoration: none;
+  border-radius: 4px;
+  transition: background 0.3s;
+}
+
+.book-btn:hover {
+  background: #c58f60;
+}
+
 .review {
   font-style: italic;
 }


### PR DESCRIPTION
## Summary
- add `.book-btn` class styling to match the accent brown

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6845e16b29f8833290e60f00e9e48146